### PR TITLE
Parpadeo del background al navegar en darkmode resuelto

### DIFF
--- a/src/layouts/PageHTML.astro
+++ b/src/layouts/PageHTML.astro
@@ -26,51 +26,33 @@ const {
   </head>
 
   <body class="w-full text-texto-sft fondo-pts">
-    <Layout client:idle>
-      <slot />
-    </Layout>
-    <script>
-      function getSystemPreference() {
-        if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-          return "enabled";
-        }
-
-        return "disabled";
-      }
-      function getThemeFromLocalStorage() {
-        const themeStr = localStorage.getItem("theme");
-        if (!themeStr) {
-          return null;
-        }
-
-        try {
-          return JSON.parse(themeStr);
-        } catch (err) {
-          return null;
-        }
-      }
-
+    <script is:inline>
+      let getThemePreference = () => {
+        const localItem =
+          typeof localStorage !== "undefined" && localStorage.getItem("theme");
+        if (localItem) return localItem;
+        return window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "enabled"
+          : "disabled";
+      };
+      const {darkMode} = JSON.parse(getThemePreference());
       function enableDarkMode() {
         document.body.classList.add("oscuro");
       }
-
       function disableDarkMode() {
         document.body.classList.remove("oscuro");
       }
-
       function setThemeOnNavigation() {
-        const {darkMode} = getThemeFromLocalStorage() || getSystemPreference();
-
         if (darkMode === "enabled") {
           enableDarkMode();
         } else {
           disableDarkMode();
         }
       }
-
-      document.addEventListener("DOMContentLoaded", () => {
-        setThemeOnNavigation();
-      });
+      setThemeOnNavigation();
     </script>
+    <Layout client:idle>
+      <slot />
+    </Layout>
   </body>
 </html>


### PR DESCRIPTION
## Descripción
1: las funciones getSystemPreference and getThemFromLocalStorage se mergearon en una sola llamada getThemePreference
2: se agrega la directiva is:inline por temas de client-side rendering and interactivity, de esta manera astro no procesa el JS y se carga justo antes de que el body o el document sea renderizado
3: se cambia de posicion, antes el script estaba despues del layout, y ahora esta antes, es decir al inicio del body
4: se elimina del script el evento domcontentloaded para asegurar que el JS corra antes de que el documento cargue

en si, toda la pr es un refactor, donde no se eliminan ni se agregan dependencias.

## Problema solucionado

elimina el parpadeo del background al navegar en modo oscuro. antes por la posicion del script y el evento domconntenloaded, el JS para actualizar las clases del body con "oscuro" ocurrian despues de que el documento cargara y fuera renderizado por esto ocurria el parpadeo

## Capturas de pantallas del codigo para visualizar mas facil los cambios que hice.

![image](https://github.com/lasfito/lasfi.to/assets/86269566/8c7b9dff-25f0-475f-b499-e7537601220d)

![image](https://github.com/lasfito/lasfi.to/assets/86269566/dfc23b3e-78cf-4f55-97c8-581d8b9fa706)



## Comprobación de cambios
me tome la molestia de hacer un despliegue de mi propia rama en vercel para verificar los cambios y comprobar que el sitio no esta roto como te comente por alla en discord xd, y aunque el video lo grabe en mi localhost, la funcionalidad es la misma

https://github.com/lasfito/lasfi.to/assets/86269566/9132738e-fd20-4543-868c-5fe1a8d9e456


sin mas que agregar creo que solo te queda por aceptar la pull request bro :V
